### PR TITLE
Injeta dependência do Database no model e refatora testes de integração

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 Flask
 dataset
 mysqlclient
+mock

--- a/src/commands/get_customer_luck_numbers.py
+++ b/src/commands/get_customer_luck_numbers.py
@@ -2,14 +2,14 @@
 # -*- coding: utf-8 -*-
 from helpers.validator import Validator
 from models.pincode import Pincode
-
+from helpers.database import DatabaseHelper
 class GetCustomerLuckNumbersCommand(object):
     @staticmethod
     def call(cpf, pincode):
         if not Validator.cpf_validator(cpf): return { 'error': 'CPF inválido' }
         if not Validator.pincode_validator(pincode): return { 'error': 'Pincode inválido' }
 
-        pincode = Pincode(pincode)
+        pincode = Pincode(pincode, DatabaseHelper)
 
         try:
             pincode.save()

--- a/src/models/pincode.py
+++ b/src/models/pincode.py
@@ -1,10 +1,9 @@
 from exception.invalid_pincode_exception import InvalidPincodeException
-from helpers.database import DatabaseHelper
 
 class Pincode(object):
-    def __init__(self, pincode):
+    def __init__(self, pincode, Database):
         self.pincode = pincode
-        self.db = DatabaseHelper('pincodes')
+        self.db = Database('pincodes')
 
     def save(self):
         pincode_from_database = self.db.find_one("pincode = '%s'" % self.pincode)

--- a/src/test/test_helpers/database_faker.py
+++ b/src/test/test_helpers/database_faker.py
@@ -1,0 +1,19 @@
+data = []
+global data
+class DatabaseHelper(object):
+    def __init__(self, table):
+        pass
+
+    def insert(self, new_data):
+        data.append(new_data)
+
+    def find_one(self, query):
+        if (len(data) >= 1):
+            return data[0]
+
+        return None
+
+    @staticmethod
+    def clean_db():
+        global data
+        data = []

--- a/src/test/tests_get_customer_luck_numbers_command.py
+++ b/src/test/tests_get_customer_luck_numbers_command.py
@@ -1,13 +1,10 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 import unittest
+from mock import patch, MagicMock
 from commands.get_customer_luck_numbers import GetCustomerLuckNumbersCommand
-from test_helpers.database import DatabaseTestHelper
-
+from test_helpers.database_faker import DatabaseHelper
 class TestGetCustomerLuckNumbersCommand(unittest.TestCase):
-    def tearDown(self):
-        DatabaseTestHelper.clean_table('pincodes')
-
     def test_return_invalid_cpf_when_cpf_is_invalid(self):
         # given
         invalid_cpf = '111'
@@ -26,6 +23,7 @@ class TestGetCustomerLuckNumbersCommand(unittest.TestCase):
         result = GetCustomerLuckNumbersCommand.call(cpf, invalid_pincode)
         # then
         self.assertEqual(result['error'], expected_error)
+    @patch('commands.get_customer_luck_numbers.DatabaseHelper', DatabaseHelper)
     def test_return_pincode_when_cpf_and_pincode_are_valid(self):
         # given
         cpf = '35818079805'

--- a/src/test/tests_main.py
+++ b/src/test/tests_main.py
@@ -2,16 +2,17 @@
 # -*- coding: utf-8 -*-
 import unittest
 from main import app as my_app
-from test_helpers.database import DatabaseTestHelper
 import json
-
+from mock import patch, MagicMock
+from test_helpers.database_faker import DatabaseHelper
 
 class TestMain(unittest.TestCase):
 
     def setUp(self):
+        DatabaseHelper.clean_db()
         self.app = my_app.test_client()
-        DatabaseTestHelper.clean_table('pincodes')
 
+    @patch('commands.get_customer_luck_numbers.DatabaseHelper', DatabaseHelper)
     def test_returns_pincode(self):
         # given
         data = {'cpf': '35818079805', 'pincode': '1q2w3e4r5t'}
@@ -21,6 +22,7 @@ class TestMain(unittest.TestCase):
         self.assertEqual(res.status_code, 201)
         self.assertIn(data['pincode'], str(res.data))
 
+    @patch('commands.get_customer_luck_numbers.DatabaseHelper', DatabaseHelper)
     def test_returns_error_when_pincode_already_exists(self):
         # given
         data = {'cpf': '35818079805', 'pincode': '1q2w3e4r5t'}

--- a/src/test/tests_pincode.py
+++ b/src/test/tests_pincode.py
@@ -1,6 +1,9 @@
 import unittest
 from models.pincode import Pincode
+from helpers.database import DatabaseHelper
+
 from test_helpers.database import DatabaseTestHelper
+
 from exception.invalid_pincode_exception import InvalidPincodeException
 
 class TestPincode (unittest.TestCase):
@@ -10,7 +13,7 @@ class TestPincode (unittest.TestCase):
 
     def test_save_pincode_in_database(self):
         # given
-        pincode = Pincode(self.global_pincode)
+        pincode = Pincode(self.global_pincode, DatabaseHelper)
         # when
         pincode.save()
 
@@ -23,7 +26,7 @@ class TestPincode (unittest.TestCase):
 
     def test_throws_exception_when_pincode_is_already_used(self):
         # given
-        pincode = Pincode(self.global_pincode)
+        pincode = Pincode(self.global_pincode, DatabaseHelper)
         # when
         pincode.save()
         # then


### PR DESCRIPTION
Agora o model recebe o database no `init`, portanto conseguimos injetar ele, e assim facilita os testes.

Deste modo apenas no teste do model estamos usando a camada de persistência real, nos demais estamos usando uma fake.

Acabei utilizando o próprio `patch`, para não ter que no Command passar o database. Uma outra abordagem, para aí sim evitar até o `patch` seria criar uma camada de [`factories`](https://sourcemaking.com/design_patterns/factory_method), e nela termos instanciar o Command, como o Database, e passar esse Database para o model.
